### PR TITLE
Add header, about, footer pages + update nav

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>About — Arsalan A. Khan</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <!-- include header -->
+  <header>
+    <div class="nav-container">
+      <h1 class="site-logo"><a href="index.html">Nucleus Dojo</a></h1>
+      <nav>
+        <ul class="site-nav">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="faq.html">FAQs</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="about-content">
+    <h2>About Arsalan A. Khan</h2>
+    <p>
+      I’m Arsalan “Archoo” A. Khan, a CLI-native builder, technical writer, and execution systems architect based in Lynnwood, WA.  
+      Over dozens of chats stored in my ZleoRootmap memory—spanning projects like Sophie AI Workspaces, MkDocs portfolios, and my personal Bloomberg-style terminal—I’ve honed a “real-time feedback” approach to AI, automation, and documentation.  
+      I specialize in:
+    </p>
+    <ul>
+      <li>Developer-first documentation (CLI + SDK guides, API references)</li>
+      <li>AI agent architectures with RAG and chaining</li>
+      <li>Modular, hands-on Python tooling & TUI/CLI utilities</li>
+    </ul>
+    <h3>Contact</h3>
+    <ul>
+      <li>Email: <a href="mailto:arsalan@example.com">arsalan@example.com</a></li>
+      <li>GitHub: <a href="https://github.com/timedilationv2">timedilationv2</a></li>
+      <li>LinkedIn: <a href="https://linkedin.com/in/arsalan-arif-khan">/arsalan-arif-khan</a></li>
+    </ul>
+  </main>
+
+  <!-- include footer -->
+  <footer>
+    <div class="footer-container">
+      <p>&copy; 2025 Arsalan A. Khan. All rights reserved.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/footer.html
+++ b/footer.html
@@ -1,0 +1,6 @@
+<footer>
+  <div class="footer-container">
+    <p>&copy; 2025 Arsalan A. Khan. All rights reserved.</p>
+    <p><small>Built with 💻 in the CLI.</small></p>
+  </div>
+</footer>

--- a/header.html
+++ b/header.html
@@ -1,0 +1,12 @@
+<header>
+  <div class="nav-container">
+    <h1 class="site-logo"><a href="index.html">Nucleus Dojo</a></h1>
+    <nav>
+      <ul class="site-nav">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="faq.html">FAQs</a></li>
+      </ul>
+    </nav>
+  </div>
+</header>

--- a/index.html
+++ b/index.html
@@ -156,6 +156,7 @@
                 <a href="#solution" class="nav-link text-secondary font-semibold">The Solution</a>
                 <a href="#applications" class="nav-link text-secondary font-semibold">Applications</a>
                 <a href="#technology" class="nav-link text-secondary font-semibold">Technology</a>
+                <a href="about.html" class="nav-link text-secondary font-semibold">About</a>
                 <a href="faq.html" class="nav-link text-secondary font-semibold">FAQs</a>
                 <a href="#contact" class="bg-accent text-white font-semibold py-2 px-6 rounded-lg hover:opacity-90 transition-opacity focusable">Request Assessment</a>
             </div>
@@ -169,6 +170,7 @@
                 <a href="#solution" class="nav-link text-secondary block px-3 py-2 rounded-md text-base font-semibold">The Solution</a>
                 <a href="#applications" class="nav-link text-secondary block px-3 py-2 rounded-md text-base font-semibold">Applications</a>
                 <a href="#technology" class="nav-link text-secondary block px-3 py-2 rounded-md text-base font-semibold">Technology</a>
+                <a href="about.html" class="nav-link text-secondary block px-3 py-2 rounded-md text-base font-semibold">About</a>
                 <a href="faq.html" class="nav-link text-secondary block px-3 py-2 rounded-md text-base font-semibold">FAQs</a>
                 <a href="#contact" class="bg-accent text-white block w-full text-left mt-2 px-3 py-2 rounded-md text-base font-semibold">Request Assessment</a>
             </div>


### PR DESCRIPTION
## Summary
- add reusable header and footer snippets
- create an about page for Arsalan A. Khan
- link to the About page from the main navigation

## Testing
- `git status --short`
- `git push origin main` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6885c7f65f8083229dd82fbf4d1449d5